### PR TITLE
Fix the error "Not allowed to navigate top frame to data URL"

### DIFF
--- a/js/controllers/MenuController.js
+++ b/js/controllers/MenuController.js
@@ -17,9 +17,15 @@ app.controller('MenuController', ['$scope', function($scope) {
         final_download["data"] = total_annotations;
 
 
-        var something = window.open("data:text/json," + encodeURIComponent(JSON.stringify(final_download)),
+        /*var something = window.open("data:text/json," + encodeURIComponent(JSON.stringify(final_download)),
             "_blank");
-        something.focus();
+        something.focus();*/
+        
+        var iframe = "<iframe width='100%' height='100%' src='" + "data:text/json," + encodeURIComponent(JSON.stringify(final_download)) + "'></iframe>"
+        var x = window.open();
+        x.document.open();
+        x.document.write(iframe);
+        x.document.close();
 
     };
 


### PR DESCRIPTION
When I click the download button, I cannot download the annotation due to the error [Not allowed to navigate top frame to data URL](https://stackoverflow.com/questions/45493234/jspdf-not-allowed-to-navigate-top-frame-to-data-url). So here I offer a pull request to fix it.