### PR TITLE
Fix to support spaces and special characters

### DIFF
--- a/web_server.js
+++ b/web_server.js
@@ -6,7 +6,7 @@ port = process.argv[2] || 8888;
 
 http.createServer(function(request, response) {
 
-    var uri = url.parse(request.url).pathname
+    var uri = decodeURI(url.parse(request.url).pathname)
         , filename = path.join(process.cwd(), uri);
 
     fs.exists(filename, function(exists) {


### PR DESCRIPTION
Using decodeURI on web_server to allow filenames with spaces and special characters like `Østers i Eske-1.jpg`